### PR TITLE
Add DeepFace verification backend

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,6 +479,8 @@
 
             let currentStream;
             let currentCaptureStep;
+            let idBlob;
+            let selfieBlob;
 
             const showDemoStep = (stepToShow) => {
                 demoSteps.forEach(step => step.classList.add('hidden'));
@@ -527,33 +529,42 @@
                 captureCanvas.width = videoFeed.videoWidth;
                 captureCanvas.height = videoFeed.videoHeight;
                 context.drawImage(videoFeed, 0, 0, videoFeed.videoWidth, videoFeed.videoHeight);
-                stopCamera();
-                
-                if (currentCaptureStep === 'id') {
-                    showDemoStep(captureSelfieBox);
-                } else if (currentCaptureStep === 'selfie') {
-                    showDemoStep(loadingBox);
-                    setTimeout(() => {
-                        const isVerified = Math.random() > 0.2; // 80% chance of success
-                        if (isVerified) {
-                            verificationKeyEl.textContent = generateKey();
-                            showDemoStep(resultBoxSuccess);
-                        } else {
-                            showDemoStep(resultBoxFailure);
-                        }
-                    }, 3000);
-                }
+                captureCanvas.toBlob(blob => {
+                    stopCamera();
+
+                    if (currentCaptureStep === 'id') {
+                        idBlob = blob;
+                        showDemoStep(captureSelfieBox);
+                    } else if (currentCaptureStep === 'selfie') {
+                        selfieBlob = blob;
+                        showDemoStep(loadingBox);
+
+                        const formData = new FormData();
+                        formData.append('id_image', idBlob, 'id.jpg');
+                        formData.append('selfie_image', selfieBlob, 'selfie.jpg');
+
+                        fetch('/verify', { method: 'POST', body: formData })
+                            .then(r => r.json())
+                            .then(data => {
+                                if (data.verified) {
+                                    verificationKeyEl.textContent = data.key;
+                                    showDemoStep(resultBoxSuccess);
+                                } else {
+                                    showDemoStep(resultBoxFailure);
+                                }
+                            })
+                            .catch(() => {
+                                showDemoStep(resultBoxFailure);
+                            });
+                    }
+                }, 'image/jpeg');
             });
             
-            const generateKey = () => {
-                const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-                let result = '';
-                for (let i = 0; i < 24; i++) result += chars.charAt(Math.floor(Math.random() * chars.length));
-                return result;
-            };
             
             const resetDemo = () => {
                 stopCamera();
+                idBlob = null;
+                selfieBlob = null;
                 copyFeedback.textContent = '';
                 const errorMessages = document.querySelectorAll('.error-text');
                 errorMessages.forEach(msg => msg.remove());

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+deepface

--- a/server.py
+++ b/server.py
@@ -1,0 +1,43 @@
+from flask import Flask, request, jsonify
+from deepface import DeepFace
+import tempfile
+import os
+import uuid
+
+app = Flask(__name__)
+
+@app.route('/verify', methods=['POST'])
+def verify():
+    if 'id_image' not in request.files or 'selfie_image' not in request.files:
+        return jsonify({'error': 'Missing images'}), 400
+    id_image = request.files['id_image']
+    selfie_image = request.files['selfie_image']
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.jpg') as id_tmp:
+        id_image.save(id_tmp.name)
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.jpg') as selfie_tmp:
+        selfie_image.save(selfie_tmp.name)
+
+    try:
+        result = DeepFace.verify(
+            img1_path=id_tmp.name,
+            img2_path=selfie_tmp.name,
+            model_name='GhostFaceNet'
+        )
+        verified = bool(result.get('verified', False))
+    except Exception as e:
+        os.remove(id_tmp.name)
+        os.remove(selfie_tmp.name)
+        return jsonify({'error': str(e)}), 500
+
+    os.remove(id_tmp.name)
+    os.remove(selfie_tmp.name)
+
+    if verified:
+        return jsonify({'verified': True, 'key': str(uuid.uuid4())})
+    else:
+        return jsonify({'verified': False})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add Flask server using DeepFace GhostFaceNet model
- capture ID and selfie images in the demo and send them to the backend
- reset stored images when starting over
- add minimal requirements list

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_685f18d1047083269576564f3b1c2e4a